### PR TITLE
feat(scene): 实现场景切换和淡入淡出效果

### DIFF
--- a/Assembly-CSharp.csproj
+++ b/Assembly-CSharp.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Assets\Scripts\Misc\SingletonMonoBehaviour.cs" />
     <Compile Include="Assets\Scripts\UI\UIInventory\UIInventoryBar.cs" />
     <Compile Include="Assets\Scripts\Item\ObscuringItemFader.cs" />
+    <Compile Include="Assets\Scripts\Scene\SceneControllerManager.cs" />
     <Compile Include="Assets\Scripts\Events\EventHandler.cs" />
     <Compile Include="Assets\Scripts\Utilities\PropertyDrawers\ItemCodeDescriptionAttribute.cs" />
     <Compile Include="Assets\Scripts\Player\PlayerUnit.cs" />

--- a/Assets/Scenes/PersistentScene.unity
+++ b/Assets/Scenes/PersistentScene.unity
@@ -473,7 +473,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 8192
   m_textAlignment: 65535
@@ -1090,7 +1090,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 8192
   m_textAlignment: 65535
@@ -1450,7 +1450,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 8192
   m_textAlignment: 65535
@@ -1494,6 +1494,54 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 947845533}
   m_CullTransparentMesh: 1
+--- !u!1 &959767284
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 959767286}
+  - component: {fileID: 959767285}
+  m_Layer: 0
+  m_Name: SceneControllerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &959767285
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959767284}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fca9576b8c2d7c244ac874f806439af8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _fadeDuration: 1
+  _fadeCanvasGroup: {fileID: 2073877635}
+  _fadeImage: {fileID: 2073877632}
+  startingScene: 0
+--- !u!4 &959767286
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 959767284}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &988062500
 GameObject:
   m_ObjectHideFlags: 0
@@ -1594,11 +1642,11 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 1643841305}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 50.952, y: -24.936}
+  m_SizeDelta: {x: 40.943, y: 6.987}
+  m_Pivot: {x: 0, y: 1}
 --- !u!114 &988641481
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1619,7 +1667,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: '0 : 00 am'
+  m_text: '0 : 00 AM'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: c7d15af53b1bce14ba6aec567df376c6, type: 2}
   m_sharedMaterial: {fileID: -8580701089954947382, guid: c7d15af53b1bce14ba6aec567df376c6, type: 2}
@@ -1652,7 +1700,7 @@ MonoBehaviour:
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
   m_fontSizeMax: 72
-  m_fontStyle: 0
+  m_fontStyle: 1
   m_HorizontalAlignment: 2
   m_VerticalAlignment: 8192
   m_textAlignment: 65535
@@ -2476,6 +2524,7 @@ RectTransform:
   m_Children:
   - {fileID: 285034536}
   - {fileID: 1643841305}
+  - {fileID: 2073877634}
   m_Father: {fileID: 1325777104}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -2810,10 +2859,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 47c56f1c1410f9747beb917d5651584f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _timeText: {fileID: 0}
-  _dateText: {fileID: 0}
-  _seasonText: {fileID: 0}
-  _yearText: {fileID: 0}
+  _timeText: {fileID: 988641481}
+  _dateText: {fileID: 947845535}
+  _seasonText: {fileID: 374879634}
+  _yearText: {fileID: 813791889}
 --- !u!114 &1643841307
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2981,6 +3030,94 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e3e29d80eabac4e45bc3be2c4a9d9cc2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &2073877631
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2073877634}
+  - component: {fileID: 2073877633}
+  - component: {fileID: 2073877632}
+  - component: {fileID: 2073877635}
+  m_Layer: 0
+  m_Name: FadeInImage
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &2073877632
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2073877631}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &2073877633
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2073877631}
+  m_CullTransparentMesh: 1
+--- !u!224 &2073877634
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2073877631}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1357358197}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!225 &2073877635
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2073877631}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 1
 --- !u!1 &2077992527
 GameObject:
   m_ObjectHideFlags: 3
@@ -4192,3 +4329,4 @@ SceneRoots:
   - {fileID: 677528671}
   - {fileID: 988062503}
   - {fileID: 1007585877}
+  - {fileID: 959767286}

--- a/Assets/Scripts/Enums/Enums.cs
+++ b/Assets/Scripts/Enums/Enums.cs
@@ -87,6 +87,13 @@ namespace Assets.Scripts.Enums
         Count
     }
 
+    public enum SceneName  // 场景名称
+    {
+        Farm,
+        Field,
+        Cabin
+    }
+
     public enum Season  // 季节
     {
         None,

--- a/Assets/Scripts/Events/EventHandler.cs
+++ b/Assets/Scripts/Events/EventHandler.cs
@@ -112,5 +112,35 @@ namespace Assets.Scripts.Events
         {
             AdvanceGameYearEvent?.Invoke(timeEventParams);
         }
+
+        // 场景切换事件
+
+        // Before Scene Unload Fade Out
+        public static event Action BeforeSceneUnloadFadeOutEvent;
+        public static void CallBeforeSceneUnloadFadeOutEvent()
+        {
+            BeforeSceneUnloadFadeOutEvent?.Invoke();
+        }
+
+        // Befor Scene Unload
+        public static event Action BeforeSceneUnloadEvent;
+        public static void CallBeforeSceneUnloadEvent()
+        {
+            BeforeSceneUnloadEvent?.Invoke();
+        }
+
+        // After Scene Load
+        public static event Action AfterSceneLoadEvent;
+        public static void CallAfterSceneLoadEvent()
+        {
+            AfterSceneLoadEvent?.Invoke();
+        }
+
+        // After Scene Load Fade In
+        public static event Action AfterSceneLoadFadeInEvent;
+        public static void CallAfterSceneLoadFadeInEvent()
+        {
+            AfterSceneLoadFadeInEvent?.Invoke();
+        }
     }
 }

--- a/Assets/Scripts/Player/PlayerUnit.cs
+++ b/Assets/Scripts/Player/PlayerUnit.cs
@@ -5,6 +5,7 @@ using Assets.Scripts.Events;
 using Assets.Scripts.Inventory;
 using Assets.Scripts.Item;
 using Assets.Scripts.Misc;
+using Assets.Scripts.Scene;
 using Assets.Scripts.TimeSystem;
 using UnityEngine;
 
@@ -97,6 +98,8 @@ namespace Assets.Scripts.Player
                 PlayerMovementInput();
                 PlayerWalkInput();
 
+                TestInput();
+
                 SetMovementParameters();
                 EventHandler.CallMovementEvent(_parameters);
             }
@@ -107,6 +110,14 @@ namespace Assets.Scripts.Player
         private void FixedUpdate()
         {
             PlayerMovement();
+        }
+
+        private void TestInput()
+        {
+            if (Input.GetKey(KeyCode.L))
+            {
+                SceneControllerManager.Instance.FadeAndLoadScene(SceneName.Farm.ToString(), transform.position);
+            }
         }
 
         public void DisablePlayerInputAndResetMovement()

--- a/Assets/Scripts/Scene/SceneControllerManager.cs
+++ b/Assets/Scripts/Scene/SceneControllerManager.cs
@@ -1,0 +1,130 @@
+using System.Collections;
+using Assets.Scripts.Enums;
+using Assets.Scripts.Events;
+using Assets.Scripts.Misc;
+using Assets.Scripts.Player;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEngine.UI;
+
+namespace Assets.Scripts.Scene
+{
+    /// <summary>
+    /// 场景控制器管理器 - 负责场景之间的切换和淡入淡出效果
+    /// </summary>
+    public class SceneControllerManager : SingletonMonoBehaviour<SceneControllerManager>
+    {
+        private bool _isFading;
+        [SerializeField] private float _fadeDuration = 1f;
+        [SerializeField] private CanvasGroup _fadeCanvasGroup = null;
+        [SerializeField] private Image _fadeImage = null;
+        public SceneName startingScene;
+
+        /// <summary>
+        /// 初始化场景 - 在游戏开始时加载起始场景
+        /// </summary>
+        private IEnumerator Start()
+        {
+            // 设置初始黑色屏幕覆盖
+            _fadeImage.color = new Color(0, 0, 0, 1);
+            _fadeCanvasGroup.alpha = 1;
+
+            // 异步加载起始场景并设为激活状态
+            yield return StartCoroutine(LoadSceneAndSetActive(startingScene.ToString()));
+
+            // 调用场景加载完成事件
+            EventHandler.CallAfterSceneLoadEvent();
+
+            // 开始淡出效果
+            StartCoroutine(Fade(0f));
+        }
+
+        /// <summary>
+        /// 淡出并加载新场景
+        /// </summary>
+        public void FadeAndLoadScene(string sceneName, Vector3 spawnPosition)
+        {
+            // 如果正在淡入淡出，则不执行新的场景切换
+            if (_isFading)
+                return;
+
+            StartCoroutine(FadeAndSwitchScenes(sceneName, spawnPosition));
+        }
+
+        /// <summary>
+        /// 淡入淡出并切换场景的核心逻辑
+        /// </summary>
+        private IEnumerator FadeAndSwitchScenes(string sceneName, Vector3 spawnPosition)
+        {
+            // 调用场景卸载前淡出事件
+            EventHandler.CallBeforeSceneUnloadFadeOutEvent();
+
+            // 淡入（屏幕变黑）
+            yield return StartCoroutine(Fade(1f));
+
+            // 设置玩家在新场景中的位置
+            PlayerUnit.Instance.gameObject.transform.position = spawnPosition;
+
+            // 调用场景卸载前事件
+            EventHandler.CallBeforeSceneUnloadEvent();
+
+            // 卸载当前场景
+            yield return SceneManager.UnloadSceneAsync(SceneManager.GetActiveScene().buildIndex);
+
+            // 加载新场景并设为激活状态
+            yield return StartCoroutine(LoadSceneAndSetActive(sceneName));
+
+            // 调用场景加载完成事件
+            EventHandler.CallAfterSceneLoadEvent();
+
+            // 淡出（屏幕变透明）
+            yield return StartCoroutine(Fade(0f));
+
+            // 调用场景加载后淡入事件
+            EventHandler.CallAfterSceneLoadFadeInEvent();
+        }
+
+        /// <summary>
+        /// 加载场景并设为激活状态
+        /// </summary>
+        private IEnumerator LoadSceneAndSetActive(string sceneName)
+        {
+            // 异步加载场景（使用Additive模式）
+            yield return SceneManager.LoadSceneAsync(sceneName, LoadSceneMode.Additive);
+
+            // 获取刚刚加载的场景（场景列表中的最后一个）
+            var newlyLoadedScene = SceneManager.GetSceneAt(SceneManager.sceneCount - 1);
+
+            // 将新场景设为激活状态
+            SceneManager.SetActiveScene(newlyLoadedScene);
+        }
+
+        /// <summary>
+        /// 淡入淡出效果实现
+        /// </summary>
+        private IEnumerator Fade(float finalAlpha)
+        {
+            // 标记正在进行淡入淡出操作
+            _isFading = true;
+
+            // 在淡入淡出过程中阻止射线检测（防止用户交互）
+            _fadeCanvasGroup.blocksRaycasts = true;
+
+            // 计算淡入淡出速度
+            float fadeSpeed = Mathf.Abs(_fadeCanvasGroup.alpha - finalAlpha) / _fadeDuration;
+
+            // 执行淡入淡出动画，直到达到目标透明度
+            while (!Mathf.Approximately(_fadeCanvasGroup.alpha, finalAlpha))
+            {
+                _fadeCanvasGroup.alpha = Mathf.MoveTowards(_fadeCanvasGroup.alpha, finalAlpha, fadeSpeed * Time.deltaTime);
+                yield return null;
+            }
+
+            // 淡入淡出操作完成
+            _isFading = false;
+
+            // 恢复射线检测（允许用户交互）
+            _fadeCanvasGroup.blocksRaycasts = false;
+        }
+    }
+}

--- a/Assets/Scripts/Scene/SceneControllerManager.cs.meta
+++ b/Assets/Scripts/Scene/SceneControllerManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fca9576b8c2d7c244ac874f806439af8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: -90
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Scene/SwitchConfineBoundingShape.cs
+++ b/Assets/Scripts/Scene/SwitchConfineBoundingShape.cs
@@ -1,15 +1,19 @@
 using Cinemachine;
 using UnityEngine;
 using Assets.Scripts.Misc;
+using Assets.Scripts.Events;
 
 namespace Assets.Scripts.Scene
 {
     [RequireComponent(typeof(CinemachineConfiner2D))]
     public class SwitchConfineBoundingShape : MonoBehaviour
     {
-        void Start()
-        {
-            SwitchBoundingShape();
+        private void OnEnable() {
+            EventHandler.AfterSceneLoadEvent += SwitchBoundingShape;
+        }
+
+        private void OnDisable() {
+            EventHandler.AfterSceneLoadEvent -= SwitchBoundingShape;
         }
 
         /// <summary>

--- a/Assets/Scripts/UI/UIInventory/UIInventorySlot.cs
+++ b/Assets/Scripts/UI/UIInventory/UIInventorySlot.cs
@@ -1,5 +1,5 @@
-using System;
 using Assets.Scripts.Enums;
+using Assets.Scripts.Events;
 using Assets.Scripts.Inventory;
 using Assets.Scripts.Item;
 using Assets.Scripts.Misc;
@@ -37,10 +37,19 @@ namespace Assets.Scripts.UI.UIInventory
             _parentCanvas = GetComponentInParent<Canvas>();
         }
 
+        private void OnEnable()
+        {
+            EventHandler.AfterSceneLoadEvent += SceneLoaded;
+        }
+
+        private void OnDisable()
+        {
+            EventHandler.AfterSceneLoadEvent -= SceneLoaded;
+        }
+
         private void Start()
         {
             _mainCamera = Camera.main;
-            _parentItem = GameObject.FindWithTag(Tags.ItemsParentTransform).transform;
         }
 
         private void SetTextParameters()
@@ -212,6 +221,11 @@ namespace Assets.Scripts.UI.UIInventory
             InventoryManager.Instance.ClearSelectedInventoryItem(InventoryLocation.Player);
 
             PlayerUnit.Instance.ClearCarriedItem();
+        }
+
+        private void SceneLoaded()
+        {
+            _parentItem = GameObject.FindGameObjectWithTag(Tags.ItemsParentTransform).transform;
         }
     }
 }


### PR DESCRIPTION
- 新增 SceneControllerManager 类，负责场景之间的切换和淡入淡出效果
- 在 PersistentScene 中添加 FadeInImage 对象，用于实现淡入淡出视觉效果
- 更新 PlayerUnit 类，添加测试输入以触发场景切换
- 修改 SwitchConfineBoundingShape 和 UIInventorySlot 类，使其在场景加载后重新初始化
- 在 EventHandler 中添加场景切换相关事件