### PR TITLE
feat(Map): 添加地面挖掘显示功能

### DIFF
--- a/Assets/Prefabs/Maps/Tilemap Grid.prefab
+++ b/Assets/Prefabs/Maps/Tilemap Grid.prefab
@@ -538,7 +538,7 @@ GameObject:
   - component: {fileID: 1971268851975794843}
   m_Layer: 0
   m_Name: Ground Decoration 1
-  m_TagString: Untagged
+  m_TagString: GroundDecoration1
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3202,7 +3202,7 @@ GameObject:
   - component: {fileID: 199344970574606603}
   m_Layer: 0
   m_Name: Ground Decoration 2
-  m_TagString: Untagged
+  m_TagString: GroundDecoration2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/CabinHome.unity
+++ b/Assets/Scenes/CabinHome.unity
@@ -1584,7 +1584,7 @@ GameObject:
   - component: {fileID: 7000830420704647938}
   m_Layer: 0
   m_Name: Ground Decoration 2
-  m_TagString: Untagged
+  m_TagString: GroundDecoration2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -5302,7 +5302,7 @@ GameObject:
   - component: {fileID: 8698878115298564754}
   m_Layer: 0
   m_Name: Ground Decoration 1
-  m_TagString: Untagged
+  m_TagString: GroundDecoration1
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/Farm.unity
+++ b/Assets/Scenes/Farm.unity
@@ -20328,7 +20328,7 @@ GameObject:
   - component: {fileID: 2918527548657445855}
   m_Layer: 0
   m_Name: Ground Decoration 1
-  m_TagString: Untagged
+  m_TagString: GroundDecoration1
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -105379,7 +105379,7 @@ GameObject:
   - component: {fileID: 3539790781205719631}
   m_Layer: 0
   m_Name: Ground Decoration 2
-  m_TagString: Untagged
+  m_TagString: GroundDecoration2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/Field.unity
+++ b/Assets/Scenes/Field.unity
@@ -55559,7 +55559,7 @@ GameObject:
   - component: {fileID: 4579221583568497312}
   m_Layer: 0
   m_Name: Ground Decoration 1
-  m_TagString: Untagged
+  m_TagString: GroundDecoration1
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -109821,7 +109821,7 @@ GameObject:
   - component: {fileID: 2743752544331623216}
   m_Layer: 0
   m_Name: Ground Decoration 2
-  m_TagString: Untagged
+  m_TagString: GroundDecoration2
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Scenes/PersistentScene.unity
+++ b/Assets/Scenes/PersistentScene.unity
@@ -152,11 +152,27 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 764e2d087ae288d4dad3813a2efff7cc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  grid: {fileID: 0}
   _so_gridPropertiesArray:
   - {fileID: 11400000, guid: 56efa68254622994a943690b47c96f33, type: 2}
   - {fileID: 11400000, guid: aaf6009c044b0124ab3a8c985309fdb1, type: 2}
   - {fileID: 11400000, guid: 8807ae01dd1da7d498c3a012bc4f846d, type: 2}
+  dugGround:
+  - {fileID: 11400000, guid: 1946ccd65d381de44afc6a6a03e17c8b, type: 2}
+  - {fileID: 11400000, guid: 6b17976c424729a4f812e3df549a07a2, type: 2}
+  - {fileID: 11400000, guid: 5f9ee2f2ca53b6349bfc490f83986ee3, type: 2}
+  - {fileID: 11400000, guid: 185c5a8ca44af9647ab97419e9246ed7, type: 2}
+  - {fileID: 11400000, guid: 71ee887264a727547a63dcc6718503cc, type: 2}
+  - {fileID: 11400000, guid: 97b916cc81972c240bba591b6a5dc131, type: 2}
+  - {fileID: 11400000, guid: 412d9be6034e09c48a68abb719e989d7, type: 2}
+  - {fileID: 11400000, guid: 67af7836345eb82488e4a5b16b706974, type: 2}
+  - {fileID: 11400000, guid: fe9a3c0d4af0060408346e016be2a475, type: 2}
+  - {fileID: 11400000, guid: 14485a0891f2dd849b9a2c341ca3141b, type: 2}
+  - {fileID: 11400000, guid: 04405b49ad5922941bbc6174d0122536, type: 2}
+  - {fileID: 11400000, guid: 1a946eb565d8b334dbfbe0339da845fa, type: 2}
+  - {fileID: 11400000, guid: 1adbca46d484baf40972643a16a5bc19, type: 2}
+  - {fileID: 11400000, guid: f9193658716409045b58f23dc7b35547, type: 2}
+  - {fileID: 11400000, guid: 60e713b773034b2408ab9b95fa3499d6, type: 2}
+  - {fileID: 11400000, guid: 7dbea6d890c966c498b7442cc25169ae, type: 2}
 --- !u!114 &64426673
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1661,9 +1677,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fca9576b8c2d7c244ac874f806439af8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _fadeDuration: 1
   _fadeCanvasGroup: {fileID: 2073877635}
   _fadeImage: {fileID: 2073877632}
+  _fadeDuration: 1
   startingScene: 0
 --- !u!4 &959767286
 Transform:

--- a/Assets/Scripts/Map/GridPropertyManager.cs
+++ b/Assets/Scripts/Map/GridPropertyManager.cs
@@ -5,6 +5,7 @@ using Assets.Scripts.Misc;
 using Assets.Scripts.SaveSystem;
 using Assets.Scripts.Scene;
 using UnityEngine;
+using UnityEngine.Tilemaps;
 
 namespace Assets.Scripts.Map
 {
@@ -16,7 +17,30 @@ namespace Assets.Scripts.Map
     {
         #region Fields
 
-        [HideInInspector] public Grid grid;
+        private Grid _grid;
+        private Tilemap _groundDecoration1;
+        private Tilemap _groundDecoration2;
+
+        // 创建位掩码查找表，索引是位掩码值，值是dugGround数组的索引
+        private static readonly int[] TileMaskToIndex = new int[]
+        {
+            0,  // 0000: 没有挖掘
+            13, // 0001: 只有右边挖掘
+            15, // 0010: 只有左边挖掘  
+            14, // 0011: 左右挖掘
+            4,  // 0100: 只有下面挖掘
+            1,  // 0101: 下面和右边挖掘
+            3,  // 0110: 下面和左边挖掘
+            2,  // 0111: 下面、左边、右边挖掘
+            12, // 1000: 只有上面挖掘
+            9,  // 1001: 上面和右边挖掘
+            11, // 1010: 上面和左边挖掘
+            10, // 1011: 上面、左边、右边挖掘
+            8,  // 1100: 上下挖掘
+            5,  // 1101: 上下右挖掘
+            7,  // 1110: 上下左挖掘
+            6   // 1111: 四个方向都挖掘
+        };
 
         /// <summary>
         /// 网格属性详情字典，用于存储场景中各个网格的属性信息
@@ -27,6 +51,11 @@ namespace Assets.Scripts.Map
         /// 网格属性配置数组，包含各个场景的网格属性配置
         /// </summary>
         [SerializeField] private SO_GridProperties[] _so_gridPropertiesArray = null;
+
+        /// <summary>
+        /// 被挖掘的地面
+        /// </summary>
+        [SerializeField] private Tile[] dugGround = null;
 
         /// <summary>
         /// 可保存对象的唯一ID
@@ -45,19 +74,19 @@ namespace Assets.Scripts.Map
         /// <summary>
         /// ISaveable接口的唯一ID属性
         /// </summary>
-        public string ISaveableUniqueID 
-        { 
-            get => _ISaveableUniqueID; 
-            set => _ISaveableUniqueID = value; 
+        public string ISaveableUniqueID
+        {
+            get => _ISaveableUniqueID;
+            set => _ISaveableUniqueID = value;
         }
 
         /// <summary>
         /// ISaveable接口的游戏对象保存数据属性
         /// </summary>
-        public GameObjectSave GameObjectSave 
-        { 
-            get => _gameObjectSave; 
-            set => _gameObjectSave = value; 
+        public GameObjectSave GameObjectSave
+        {
+            get => _gameObjectSave;
+            set => _gameObjectSave = value;
         }
 
         #endregion
@@ -137,6 +166,13 @@ namespace Assets.Scripts.Map
                 return;
 
             _gridPropertyDetailsDictionary = sceneSave.gridPropertyDetailsDictionary;
+
+            if (_gridPropertyDetailsDictionary.Count > 0)
+            {
+                ClearDisplayGridPropertyDetails();
+
+                DisplayGridPropertyDetails();
+            }
         }
 
         #endregion
@@ -148,7 +184,10 @@ namespace Assets.Scripts.Map
         /// </summary>
         private void AfterSceneLoad()
         {
-            grid = FindObjectOfType<Grid>();
+            _grid = FindObjectOfType<Grid>();
+
+            _groundDecoration1 = GameObject.FindGameObjectWithTag(Tags.GroundDecoration1).GetComponent<Tilemap>();
+            _groundDecoration2 = GameObject.FindGameObjectWithTag(Tags.GroundDecoration2).GetComponent<Tilemap>();
         }
 
         #endregion
@@ -171,8 +210,8 @@ namespace Assets.Scripts.Map
                 {
                     // 获取指定坐标的网格属性详情，如果不存在则创建新的
                     GridPropertyDetails gridPropertyDetails = GetGridPropertyDetails(
-                        gridProperty.gridCoordinate.x, 
-                        gridProperty.gridCoordinate.y, 
+                        gridProperty.gridCoordinate.x,
+                        gridProperty.gridCoordinate.y,
                         gridPropertyDetailsDictionary) ?? new GridPropertyDetails();
 
                     // 根据属性类型设置相应的布尔值
@@ -199,9 +238,9 @@ namespace Assets.Scripts.Map
 
                     // 更新网格坐标信息并保存到字典中
                     SetGridPropertyDetails(
-                        gridProperty.gridCoordinate.x, 
-                        gridProperty.gridCoordinate.y, 
-                        gridPropertyDetails, 
+                        gridProperty.gridCoordinate.x,
+                        gridProperty.gridCoordinate.y,
+                        gridPropertyDetails,
                         gridPropertyDetailsDictionary);
                 }
 
@@ -280,6 +319,112 @@ namespace Assets.Scripts.Map
         public void SetGridPropertyDetails(int gridX, int gridY, GridPropertyDetails gridPropertyDetails)
         {
             SetGridPropertyDetails(gridX, gridY, gridPropertyDetails, _gridPropertyDetailsDictionary);
+        }
+
+        #endregion
+
+        #region Ground Decoration Management
+
+        /// <summary>
+        /// 显示已 dug 的地面装饰
+        /// </summary>
+        /// <param name="gridPropertyDetails"></param>
+        public void DisplayDugGround(GridPropertyDetails gridPropertyDetails)
+        {
+            if (gridPropertyDetails.daysSinceLastDig > -1)
+            {
+                ConnectDugGround(gridPropertyDetails);
+            }
+        }
+
+        private void DisplayGridPropertyDetails()
+        {
+            foreach (var item in _gridPropertyDetailsDictionary)
+            {
+                GridPropertyDetails gridPropertyDetails = item.Value;
+
+                DisplayDugGround(gridPropertyDetails);
+            }
+        }
+
+        /// <summary>
+        /// 清除显示的装饰
+        /// </summary>
+        private void ClearDisplayGroundDecorations()
+        {
+            _groundDecoration1.ClearAllTiles();
+            _groundDecoration2.ClearAllTiles();
+        }
+
+        /// <summary>
+        /// 清除显示的属性
+        /// </summary>
+        private void ClearDisplayGridPropertyDetails()
+        {
+            ClearDisplayGroundDecorations();
+        }
+
+        private void ConnectDugGround(GridPropertyDetails gridPropertyDetails)
+        {
+            // 设置当前格子的挖掘贴图
+            Tile dugTile0 = SetDugTile(gridPropertyDetails.gridX, gridPropertyDetails.gridY);
+            _groundDecoration1.SetTile(new Vector3Int(gridPropertyDetails.gridX, gridPropertyDetails.gridY, 0), dugTile0);
+
+            // 定义四个相邻方向的偏移量：上、下、左、右
+            Vector2Int[] adjacentOffsets = {
+                new(0, 1),   // 上
+                new(0, -1),  // 下
+                new(-1, 0),  // 左
+                new(1, 0)    // 右
+            };
+
+            // 遍历四个相邻方向，检查是否需要更新贴图
+            foreach (Vector2Int offset in adjacentOffsets)
+            {
+                int adjacentX = gridPropertyDetails.gridX + offset.x;
+                int adjacentY = gridPropertyDetails.gridY + offset.y;
+
+                GridPropertyDetails adjacentGridPropertyDetails = GetGridPropertyDetails(adjacentX, adjacentY);
+                if (adjacentGridPropertyDetails != null && adjacentGridPropertyDetails.daysSinceLastDig > -1)
+                {
+                    Tile adjacentDugTile = SetDugTile(adjacentX, adjacentY);
+                    _groundDecoration1.SetTile(new Vector3Int(adjacentX, adjacentY, 0), adjacentDugTile);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 根据相邻格子的挖掘状态设置当前格子的挖掘贴图
+        /// </summary>
+        /// <param name="gridX">当前格子X坐标</param>
+        /// <param name="gridY">当前格子Y坐标</param>
+        /// <returns>对应的挖掘贴图</returns>
+        private Tile SetDugTile(int gridX, int gridY)
+        {
+            bool upDug = IsGridSquareDug(gridX, gridY + 1);
+            bool downDug = IsGridSquareDug(gridX, gridY - 1);
+            bool leftDug = IsGridSquareDug(gridX - 1, gridY);
+            bool rightDug = IsGridSquareDug(gridX + 1, gridY);
+
+            // 构建位掩码：右(bit0) + 左(bit1) + 下(bit2) + 上(bit3)
+            int mask = (rightDug ? 1 : 0) |
+                       (leftDug ? 2 : 0) |
+                       (downDug ? 4 : 0) |
+                       (upDug ? 8 : 0);
+
+            return dugGround[TileMaskToIndex[mask]];
+        }
+
+        /// <summary>
+        /// 检查指定坐标的格子是否已被挖掘
+        /// </summary>
+        /// <param name="gridX">格子X坐标</param>
+        /// <param name="gridY">格子Y坐标</param>
+        /// <returns>如果已被挖掘返回true，否则返回false</returns>
+        private bool IsGridSquareDug(int gridX, int gridY)
+        {
+            GridPropertyDetails gridPropertyDetails = GetGridPropertyDetails(gridX, gridY);
+            return gridPropertyDetails != null && gridPropertyDetails.daysSinceLastDig > -1;
         }
 
         #endregion

--- a/Assets/Scripts/Misc/Tags.cs
+++ b/Assets/Scripts/Misc/Tags.cs
@@ -3,6 +3,8 @@ namespace Assets.Scripts.Misc
     public static class Tags
     {
         public const string BoundsConfiner = "BoundsConfiner";
+        public const string GroundDecoration1 = "GroundDecoration1";
+        public const string GroundDecoration2 = "GroundDecoration2";
         public const string ItemsParentTransform = "ItemsParentTransform";
     }
 

--- a/Assets/Scripts/Player/PlayerUnit.cs
+++ b/Assets/Scripts/Player/PlayerUnit.cs
@@ -514,6 +514,8 @@ namespace Assets.Scripts.Player
 
             GridPropertyManager.Instance.SetGridPropertyDetails(gridPropertyDetails.gridX, gridPropertyDetails.gridY, gridPropertyDetails);
 
+            GridPropertyManager.Instance.DisplayDugGround(gridPropertyDetails);
+
             // 等待动画后延迟
             yield return _afterUseToolAnimationPause;
 

--- a/Assets/Tilemap/TilePalettes/DugGround.prefab
+++ b/Assets/Tilemap/TilePalettes/DugGround.prefab
@@ -1,0 +1,650 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1023586864812437639
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7229427664605433495}
+  - component: {fileID: 5492213034514293039}
+  m_Layer: 0
+  m_Name: DugGround
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7229427664605433495
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1023586864812437639}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5070198202145620059}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!156049354 &5492213034514293039
+Grid:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1023586864812437639}
+  m_Enabled: 1
+  m_CellSize: {x: 1, y: 1, z: 0}
+  m_CellGap: {x: 0, y: 0, z: 0}
+  m_CellLayout: 0
+  m_CellSwizzle: 0
+--- !u!1 &3197291089362921636
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5070198202145620059}
+  - component: {fileID: 1137019389179634376}
+  - component: {fileID: 1947398032959939346}
+  m_Layer: 0
+  m_Name: Layer1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5070198202145620059
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3197291089362921636}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7229427664605433495}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1839735485 &1137019389179634376
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3197291089362921636}
+  m_Enabled: 1
+  m_Tiles:
+  - first: {x: -3, y: -31, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 15
+      m_TileSpriteIndex: 15
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -2, y: -31, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 14
+      m_TileSpriteIndex: 14
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -1, y: -31, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 17
+      m_TileSpriteIndex: 17
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 0, y: -31, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 16
+      m_TileSpriteIndex: 16
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 1, y: -31, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 13
+      m_TileSpriteIndex: 13
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 2, y: -31, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 12
+      m_TileSpriteIndex: 12
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 3, y: -31, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 10
+      m_TileSpriteIndex: 10
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: -31, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 11
+      m_TileSpriteIndex: 11
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -3, y: -30, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 2
+      m_TileSpriteIndex: 2
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -2, y: -30, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 3
+      m_TileSpriteIndex: 3
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -1, y: -30, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 8
+      m_TileSpriteIndex: 8
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 0, y: -30, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 9
+      m_TileSpriteIndex: 9
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 1, y: -30, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 19
+      m_TileSpriteIndex: 19
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 2, y: -30, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 18
+      m_TileSpriteIndex: 18
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 3, y: -30, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 21
+      m_TileSpriteIndex: 21
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: -30, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 20
+      m_TileSpriteIndex: 20
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -3, y: -29, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 23
+      m_TileSpriteIndex: 23
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -2, y: -29, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 22
+      m_TileSpriteIndex: 22
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -1, y: -29, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 4
+      m_TileSpriteIndex: 4
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 0, y: -29, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 5
+      m_TileSpriteIndex: 5
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 1, y: -29, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 6
+      m_TileSpriteIndex: 6
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 2, y: -29, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 7
+      m_TileSpriteIndex: 7
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 3, y: -29, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 0
+      m_TileSpriteIndex: 0
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: -29, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 1
+      m_TileSpriteIndex: 1
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -3, y: -28, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 29
+      m_TileSpriteIndex: 29
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -2, y: -28, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 28
+      m_TileSpriteIndex: 28
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: -1, y: -28, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 31
+      m_TileSpriteIndex: 31
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 0, y: -28, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 30
+      m_TileSpriteIndex: 30
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 1, y: -28, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 25
+      m_TileSpriteIndex: 25
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 2, y: -28, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 24
+      m_TileSpriteIndex: 24
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 3, y: -28, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 27
+      m_TileSpriteIndex: 27
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  - first: {x: 4, y: -28, z: 0}
+    second:
+      serializedVersion: 2
+      m_TileIndex: 26
+      m_TileSpriteIndex: 26
+      m_TileMatrixIndex: 0
+      m_TileColorIndex: 0
+      m_TileObjectToInstantiateIndex: 65535
+      dummyAlignment: 0
+      m_AllTileFlags: 1073741825
+  m_AnimatedTiles: {}
+  m_TileAssetArray:
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 15634cfc1d36c0b4989fd4709e394cc5, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: ffcc9026671052648a5a0dd5c571e1e3, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: fe9a3c0d4af0060408346e016be2a475, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 14485a0891f2dd849b9a2c341ca3141b, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 412d9be6034e09c48a68abb719e989d7, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 67af7836345eb82488e4a5b16b706974, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 6f98e8629dbb16740a4f4b4339cd01d7, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: a8009f930b3b0e04ab6bf1bc75715707, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 04405b49ad5922941bbc6174d0122536, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 1a946eb565d8b334dbfbe0339da845fa, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: e2701816a2b24de499b895ffc17f75a6, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 032d4edb65d09f84d89ca2f48346fa0f, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 11505016f9a33264a90ab9e6a28ef4d8, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 0b81deefa84a8c64eb985580f215f0dd, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: f9193658716409045b58f23dc7b35547, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 1adbca46d484baf40972643a16a5bc19, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 7dbea6d890c966c498b7442cc25169ae, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 60e713b773034b2408ab9b95fa3499d6, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: cb649005cb252154ab768ec48a704690, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: c46c89179a11ea940820281498e5600e, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: e3ce45cb47202dc47ad19cf094614249, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 1de6a5a5a364ebb4587db94b27990465, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 97b916cc81972c240bba591b6a5dc131, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 71ee887264a727547a63dcc6718503cc, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: b863fff0b87989b4b9976261050ad163, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: f5eac7edc32b70a478511c54d920fff1, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 7c37e97460a821a49aa41af6b51a86af, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 92233ec3fdc701f48bd078f0a93eb45b, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 6b17976c424729a4f812e3df549a07a2, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 1946ccd65d381de44afc6a6a03e17c8b, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 185c5a8ca44af9647ab97419e9246ed7, type: 2}
+  - m_RefCount: 1
+    m_Data: {fileID: 11400000, guid: 5f9ee2f2ca53b6349bfc490f83986ee3, type: 2}
+  m_TileSpriteArray:
+  - m_RefCount: 1
+    m_Data: {fileID: 6933223335694393071, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -1397365509746193196, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 17334880324610018, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 7143828148132578542, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -8186299728689910322, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 7364767379561946811, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -4987229573879477163, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 818433697204119388, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 7591868225199800783, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 3174740000172749308, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 2655803857110052468, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -2961396871861752453, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -2717033803204188961, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 8316314858200970040, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 6122583050134324219, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 1301980698495550940, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -6878932850842707370, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -5750998479089953526, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -8266863679620031733, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -5815133488013185899, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 5818661052790145292, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -4872621163021313545, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -2463700668463398288, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -1144834211054590616, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 3766865763359371942, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 9185315290136886186, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -4060529681369373566, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 4104806012796865313, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -6124715397737624461, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 5588880199808461859, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: -8482852301027147495, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  - m_RefCount: 1
+    m_Data: {fileID: 7303584569058495136, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_TileMatrixArray:
+  - m_RefCount: 32
+    m_Data:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+  m_TileColorArray:
+  - m_RefCount: 32
+    m_Data: {r: 1, g: 1, b: 1, a: 1}
+  m_TileObjectToInstantiateArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: -3, y: -31, z: 0}
+  m_Size: {x: 8, y: 31, z: 1}
+  m_TileAnchor: {x: 0.5, y: 0.5, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+--- !u!483693784 &1947398032959939346
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3197291089362921636}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 0
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_Mode: 0
+  m_DetectChunkCullingBounds: 0
+  m_MaskInteraction: 0
+--- !u!114 &8257070387044004979
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 12395, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: Palette Settings
+  m_EditorClassIdentifier: 
+  cellSizing: 0
+  m_TransparencySortMode: 0
+  m_TransparencySortAxis: {x: 0, y: 0, z: 1}

--- a/Assets/Tilemap/TilePalettes/DugGround.prefab.meta
+++ b/Assets/Tilemap/TilePalettes/DugGround.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fc3c3132df297304e9540d4fc49993e3
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround.meta
+++ b/Assets/Tilemap/Tiles/DugGround.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 100103c06a5047a43996d9f52724718b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_0.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_0.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_0
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 5588880199808461859, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_0.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_0.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1946ccd65d381de44afc6a6a03e17c8b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_1.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_1.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_1
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -6124715397737624461, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_1.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_1.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6b17976c424729a4f812e3df549a07a2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_10.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_10.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_10
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -8186299728689910322, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_10.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_10.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 412d9be6034e09c48a68abb719e989d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_11.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_11.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_11
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 7364767379561946811, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_11.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_11.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 67af7836345eb82488e4a5b16b706974
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_12.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_12.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_12
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -4987229573879477163, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_12.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_12.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f98e8629dbb16740a4f4b4339cd01d7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_13.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_13.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_13
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 818433697204119388, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_13.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_13.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8009f930b3b0e04ab6bf1bc75715707
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_14.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_14.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_14
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 6933223335694393071, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_14.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_14.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15634cfc1d36c0b4989fd4709e394cc5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_15.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_15.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_15
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -1397365509746193196, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_15.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_15.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ffcc9026671052648a5a0dd5c571e1e3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_16.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_16.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_16
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 17334880324610018, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_16.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_16.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe9a3c0d4af0060408346e016be2a475
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_17.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_17.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_17
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 7143828148132578542, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_17.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_17.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 14485a0891f2dd849b9a2c341ca3141b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_18.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_18.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_18
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 7591868225199800783, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_18.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_18.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04405b49ad5922941bbc6174d0122536
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_19.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_19.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_19
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 3174740000172749308, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_19.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_19.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1a946eb565d8b334dbfbe0339da845fa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_2.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_2.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_2
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 7303584569058495136, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_2.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_2.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5f9ee2f2ca53b6349bfc490f83986ee3
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_20.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_20.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_20
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -5815133488013185899, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_20.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_20.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c46c89179a11ea940820281498e5600e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_21.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_21.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_21
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -8266863679620031733, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_21.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_21.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cb649005cb252154ab768ec48a704690
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_22.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_22.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_22
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -4872621163021313545, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_22.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_22.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1de6a5a5a364ebb4587db94b27990465
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_23.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_23.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_23
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 5818661052790145292, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_23.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_23.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e3ce45cb47202dc47ad19cf094614249
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_24.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_24.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_24
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 1301980698495550940, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_24.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_24.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1adbca46d484baf40972643a16a5bc19
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_25.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_25.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_25
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 6122583050134324219, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_25.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_25.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f9193658716409045b58f23dc7b35547
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_26.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_26.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_26
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -5750998479089953526, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_26.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_26.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60e713b773034b2408ab9b95fa3499d6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_27.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_27.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_27
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -6878932850842707370, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_27.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_27.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7dbea6d890c966c498b7442cc25169ae
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_28.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_28.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_28
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 8316314858200970040, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_28.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_28.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0b81deefa84a8c64eb985580f215f0dd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_29.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_29.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_29
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -2717033803204188961, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_29.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_29.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 11505016f9a33264a90ab9e6a28ef4d8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_3.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_3.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_3
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -8482852301027147495, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_3.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_3.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 185c5a8ca44af9647ab97419e9246ed7
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_30.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_30.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_30
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 2655803857110052468, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_30.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_30.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e2701816a2b24de499b895ffc17f75a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_31.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_31.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_31
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -2961396871861752453, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_31.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_31.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 032d4edb65d09f84d89ca2f48346fa0f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_4.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_4.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_4
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 9185315290136886186, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_4.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_4.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f5eac7edc32b70a478511c54d920fff1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_5.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_5.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_5
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 3766865763359371942, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_5.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_5.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b863fff0b87989b4b9976261050ad163
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_6.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_6.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_6
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: 4104806012796865313, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_6.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_6.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 92233ec3fdc701f48bd078f0a93eb45b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_7.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_7.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_7
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -4060529681369373566, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_7.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_7.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c37e97460a821a49aa41af6b51a86af
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_8.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_8.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_8
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -1144834211054590616, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_8.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_8.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71ee887264a727547a63dcc6718503cc
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_9.asset
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_9.asset
@@ -1,0 +1,36 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 13312, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: DugGround_9
+  m_EditorClassIdentifier: 
+  m_Sprite: {fileID: -2463700668463398288, guid: b793cccf0b10a2148b7c8e09c08ac094, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Transform:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+  m_InstancedGameObject: {fileID: 0}
+  m_Flags: 1
+  m_ColliderType: 1

--- a/Assets/Tilemap/Tiles/DugGround/DugGround_9.asset.meta
+++ b/Assets/Tilemap/Tiles/DugGround/DugGround_9.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 97b916cc81972c240bba591b6a5dc131
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -6,6 +6,8 @@ TagManager:
   tags:
   - ItemsParentTransform
   - BoundsConfiner
+  - GroundDecoration1
+  - GroundDecoration2
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- 在 GridPropertyManager 中添加显示挖掘地面的功能
- 在 PlayerUnit 中调用新功能以显示挖掘效果
- 为地面装饰对象添加标签并进行引用
- 优化了网格属性的加载和显示逻辑